### PR TITLE
Increases assault core range

### DIFF
--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -260,7 +260,7 @@
 	qdel(charge)
 	new /obj/effect/temp_visual/lightning_discharge(get_turf(chassis))
 	chassis.move_delay -= added_movetime
-	for(var/turf/location in RANGE_TURFS(1, chassis))
+	for(var/turf/location in RANGE_TURFS(2, chassis))
 		for(var/mob/living/target in location)
 			target.take_overall_damage(200, BURN, LASER, updating_health=TRUE, penetration=30, max_limbs=6)
 	playsound(chassis, 'sound/weapons/burst_phaser2.ogg', GUN_FIRE_SOUND_VOLUME, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the assault core range by an extra tile
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Assault core right now is incredibly weak, putting the mech in a vulnerable state to hit anything within 1 tile of the mech. By increasing it's range, hopefully this will make it better as a "Get off me" tool and less of a joke module.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: Increased assault armor's range by 1
/:cl:
